### PR TITLE
Feat/adjust dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ instructional designers, and administrators spend less time on managing Canvas a
 courses. LMS Dash simplifies course and LMS management tasks by offering features that are not natively available in
 Canvas. Here are some of the things LMS Dash can do:
 - Scan Courses
-- (More features coming soon)
+- 🚧 Adjust Announcement Dates (in bulk)
 
 ## Course Scanner
 One of the most important features of LMS Dash is the course scanner. Do your courses have old addresses, old links,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-select": "^5.10.0"
       },
       "devDependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.4",
@@ -1718,6 +1719,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5906,6 +5920,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,15 +30,26 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.4",
         "@tailwindcss/postcss": "^4.0.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.2.0",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
         "jest": "^29.7.0",
+        "jsdom": "^26.0.0",
         "postcss": "^8.5.2",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.9.3",
-        "vite": "^6.1.0"
+        "vite": "^6.1.0",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -66,6 +77,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -585,6 +617,121 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -3111,6 +3258,128 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3156,6 +3425,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.27.tgz",
@@ -3165,6 +3445,13 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3326,6 +3613,131 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -3337,6 +3749,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/animate.css": {
@@ -3434,6 +3856,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/babel-jest": {
@@ -3648,6 +4090,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3688,6 +4140,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3713,6 +4182,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/ci-info": {
@@ -3874,16 +4353,51 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3896,6 +4410,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -3912,6 +4433,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3920,6 +4451,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3960,6 +4501,14 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4012,6 +4561,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4020,6 +4582,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -4154,6 +4723,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4382,12 +4961,53 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4397,6 +5017,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-fresh": {
@@ -4452,6 +5085,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4523,6 +5166,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5257,6 +5907,46 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5578,6 +6268,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5586,6 +6283,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5687,6 +6395,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5768,6 +6486,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5889,6 +6614,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5932,6 +6670,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6063,6 +6818,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
@@ -6225,6 +6990,20 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6333,6 +7112,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
@@ -6381,6 +7187,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -6474,6 +7287,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6536,6 +7363,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6548,6 +7388,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -6579,6 +7439,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.0.0",
@@ -6642,6 +7509,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6658,6 +7539,56 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -6677,6 +7608,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -6907,6 +7864,115 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6915,6 +7981,54 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6931,6 +8045,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -6971,6 +8102,45 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.1.4",
+    "@js-temporal/polyfill": "^0.5.1",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "dev": "NODE_ENV=development npm run build_app",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "npx tsc --noEmit"
   },
   "dependencies": {
@@ -37,13 +40,17 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.1.4",
     "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "jest": "^29.7.0",
+    "jsdom": "^26.0.0",
     "postcss": "^8.5.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.9.3",
-    "vite": "^6.1.0"
+    "vite": "^6.1.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/ContentScript/CanvasAPIClient.ts
+++ b/src/ContentScript/CanvasAPIClient.ts
@@ -2,9 +2,11 @@ import { HTTPClient } from "./HTTPClient";
 
 export class CanvasAPIClient {
   public Get: typeof GetRequests;
+  public Put: typeof PutRequests;
 
   constructor() {
     this.Get = GetRequests;
+    this.Put = PutRequests;
   }
 
   static formatURL(url: string): string {
@@ -101,6 +103,15 @@ class GetRequests {
   static async UsersSelf(): Promise<Response> {
     return await HTTPClient.get(
       CanvasAPIClient.formatURL("/users/self")
+    );
+  }
+}
+
+class PutRequests {
+  static async Announcement(courseId: number | string, announcementId: number | string, delayedPostAt: string): Promise<Response> {
+    return await HTTPClient.put(
+      CanvasAPIClient.formatURL(`/courses/${courseId}/discussion_topics/${announcementId}`),
+      { delayed_post_at: delayedPostAt }
     );
   }
 }

--- a/src/ContentScript/RequestHandler.ts
+++ b/src/ContentScript/RequestHandler.ts
@@ -1,5 +1,5 @@
 import { CanvasAPIClient } from "./CanvasAPIClient";
-import { CanvasRequest, CanvasRequestGet } from "../shared/models/CanvasRequest";
+import { CanvasRequest, CanvasRequestType } from "../shared/models/CanvasRequest";
 import { CanvasResponse } from "../shared/models/CanvasResponse";
 
 export interface CanvasRequestParams {
@@ -12,11 +12,13 @@ export interface CanvasRequestParams {
   moduleId?: number | string;
   includeBody?: boolean;
   searchTerm?: string;
+  announcementId?: number | string;
+  delayedPostAt?: string;
 }
 
 export interface CanvasRequestLike {
   id: string;
-  type: CanvasRequestGet;
+  type: CanvasRequestType;
   params: CanvasRequestParams;
 }
 
@@ -154,8 +156,16 @@ export class RequestHandler {
         response = await this.client.Get.UsersSelf();
         break;
 
+      case CanvasRequest.Put.Announcement:
+        response = await this.client.Put.Announcement(
+          request.params.courseId!,
+          request.params.announcementId!,
+          request.params.delayedPostAt!
+        );
+        break;
+
       default:
-        console.error("Error: invalid canvas get request type passed to RequestHandler");
+        console.error("Error: invalid canvas request type passed to RequestHandler");
     }
 
     if (!response) {

--- a/src/ServiceWorker/AppController.test.ts
+++ b/src/ServiceWorker/AppController.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppController } from "./AppController";
+import { MessageHandler } from "./MessageHandler";
+import TaskController from "./TaskController";
+import { TabHandler } from "./TabHandler";
+import { CanvasResponse } from "../shared/models/CanvasResponse";
+
+describe("AppController", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockReset();
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>).mockReset();
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  });
+
+  it("updates app state from bootstrapped Canvas tabs on the next controller update", async () => {
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { id: 71, url: "https://school.instructure.com/courses/71", active: true } as chrome.tabs.Tab,
+      ])
+      .mockResolvedValueOnce([
+        { id: 71, url: "https://school.instructure.com/courses/71", active: true } as chrome.tabs.Tab,
+      ]);
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 71,
+      url: "https://school.instructure.com/courses/71",
+      active: true,
+    } as chrome.tabs.Tab);
+    vi.spyOn(MessageHandler.prototype, "sendSidePanelMessage").mockResolvedValue(undefined);
+    vi.spyOn(MessageHandler.prototype, "sendCanvasRequests").mockResolvedValue([
+      new CanvasResponse("test-uuid", "[]", false, null, true, false, 200, "OK", "basic"),
+    ]);
+
+    const controller = new AppController();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await controller.update();
+
+    expect(controller.state.hasTabs).toBe(true);
+    expect(controller.state.activeTabId).toBe(71);
+    expect(controller.state.activeTab?.url).toBe("https://school.instructure.com/courses/71");
+  });
+
+  it("notifies the side panel when tab availability changes", async () => {
+    vi.spyOn(TabHandler.prototype, "hasTabs")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    vi.spyOn(TabHandler.prototype, "getLastActiveTabId").mockReturnValue(88);
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 88,
+      url: "https://school.instructure.com/courses/88/pages/home",
+      active: true,
+    } as chrome.tabs.Tab);
+    const sendSidePanelMessageSpy = vi.spyOn(MessageHandler.prototype, "sendSidePanelMessage").mockResolvedValue(undefined);
+    vi.spyOn(MessageHandler.prototype, "sendCanvasRequests").mockResolvedValue([
+      new CanvasResponse("test-uuid", "[]", false, null, true, false, 200, "OK", "basic"),
+    ]);
+
+    const controller = new AppController();
+    await controller.update();
+
+    expect(controller.state.hasTabs).toBe(true);
+    expect(controller.state.activeTabId).toBe(88);
+    expect(sendSidePanelMessageSpy).toHaveBeenCalledWith("app state", controller.state);
+  });
+
+  it("does not notify the side panel when state is unchanged", async () => {
+    vi.spyOn(TabHandler.prototype, "hasTabs").mockReturnValue(false);
+    vi.spyOn(TabHandler.prototype, "getLastActiveTabId").mockReturnValue(null);
+    const sendSidePanelMessageSpy = vi.spyOn(MessageHandler.prototype, "sendSidePanelMessage").mockResolvedValue(undefined);
+
+    const controller = new AppController();
+    sendSidePanelMessageSpy.mockClear();
+
+    await controller.update();
+
+    expect(sendSidePanelMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("updates admin state from Canvas permission checks when tabs exist", async () => {
+    vi.spyOn(TabHandler.prototype, "hasTabs").mockReturnValue(true);
+    vi.spyOn(TabHandler.prototype, "getLastActiveTabId").mockReturnValue(91);
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 91,
+      url: "https://school.instructure.com/courses/91",
+      active: true,
+    } as chrome.tabs.Tab);
+    vi.spyOn(MessageHandler.prototype, "sendSidePanelMessage").mockResolvedValue(undefined);
+    vi.spyOn(MessageHandler.prototype, "sendCanvasRequests").mockResolvedValue([
+      new CanvasResponse("test-uuid", "[]", false, null, true, false, 200, "OK", "basic"),
+    ]);
+
+    const controller = new AppController();
+    await controller.update();
+
+    expect(controller.state.isAdmin).toBe(true);
+    expect(controller.countCheckedIsAdmin).toBe(1);
+  });
+
+  it("delegates task updates to TaskController", () => {
+    const updateSpy = vi.spyOn(TaskController.prototype, "update").mockImplementation(() => undefined);
+
+    const controller = new AppController();
+    const didUpdate = controller.updateTasks();
+
+    expect(didUpdate).toBe(true);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ServiceWorker/MessageHandler.test.ts
+++ b/src/ServiceWorker/MessageHandler.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MessageHandler } from "./MessageHandler";
+import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "../shared/models/Message";
+import { AppState } from "../shared/models/AppState";
+import Task, { TaskStatuses, TaskTypes } from "../shared/models/Task";
+import { CanvasResponse } from "../shared/models/CanvasResponse";
+import { CanvasRequest } from "../shared/models/CanvasRequest";
+
+describe("MessageHandler", () => {
+  const makeAppController = () => {
+    const state = new AppState();
+    return {
+      state,
+      setSidePanelOpen: vi.fn(() => {
+        state.hasOpenSidePanel = true;
+      }),
+      tabHandler: {
+        getTabId: vi.fn(() => 123),
+      },
+      taskController: {
+        stopTask: vi.fn(() => true),
+        enqueue: vi.fn((task: Task) => task),
+        getTaskById: vi.fn(),
+        getTasksByType: vi.fn(),
+      },
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns app state when the side panel announces it opened", async () => {
+    const appController = makeAppController();
+    const handler = new MessageHandler(appController);
+    const sendResponse = vi.fn();
+
+    await handler.handleSidePanelMessage(
+      new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Task.Request.App.SET_PANEL_OPENED,
+        "opened"
+      ),
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(appController.setSidePanelOpen).toHaveBeenCalledTimes(1);
+    const response = sendResponse.mock.calls[0][0] as Message;
+    expect(response.type).toBe(MESSAGE_TYPE.Task.Response.App.SET_PANEL_OPENED);
+    expect(response.data).toBe(appController.state);
+    expect(appController.state.hasOpenSidePanel).toBe(true);
+  });
+
+  it("requests the current user from Canvas for USER info messages", async () => {
+    const appController = makeAppController();
+    const handler = new MessageHandler(appController);
+    const sendResponse = vi.fn();
+    const userInfoRequest = new CanvasRequest(CanvasRequest.Get.UsersSelf);
+    const canvasResponses = [
+      new CanvasResponse(userInfoRequest.id, '{"name":"Teacher"}', false, null, true, false, 200, "OK", "basic"),
+    ];
+    const sendCanvasRequestsSpy = vi.spyOn(handler, "sendCanvasRequests").mockResolvedValue(canvasResponses);
+
+    await handler.handleSidePanelMessage(
+      new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Task.Request.Info.USER,
+        "user"
+      ),
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(sendCanvasRequestsSpy).toHaveBeenCalledTimes(1);
+    const requests = sendCanvasRequestsSpy.mock.calls[0][0];
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.type).toBe(CanvasRequest.Get.UsersSelf);
+
+    const response = sendResponse.mock.calls[0][0] as Message;
+    expect(response.type).toBe(MESSAGE_TYPE.Task.Response.Info.USER);
+    expect(response.data).toEqual(canvasResponses);
+    expect(response.data[0]?.id).toBe(userInfoRequest.id);
+  });
+
+  it("returns a serializable task copy with results for BY_ID requests", async () => {
+    const appController = makeAppController();
+    const task = new Task(TaskTypes.coursesScan, { searchTerms: ["retired faculty name"] });
+    task.setId(4);
+    task.setStatus(TaskStatuses.RUNNING);
+    task.controller = { stop: vi.fn() };
+    task.resultsData = { hidden: true };
+    appController.taskController.getTaskById.mockReturnValue(task);
+
+    const handler = new MessageHandler(appController);
+    const sendResponse = vi.fn();
+
+    await handler.handleSidePanelMessage(
+      new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Task.Request.BY_ID,
+        "task by id",
+        4
+      ),
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    const response = sendResponse.mock.calls[0][0] as Message;
+    expect(response.type).toBe(MESSAGE_TYPE.Task.Response.BY_ID);
+    expect(response.data).toMatchObject({
+      id: 4,
+      type: TaskTypes.coursesScan,
+      status: TaskStatuses.RUNNING,
+      settingsData: { searchTerms: ["retired faculty name"] },
+    });
+    expect(response.data.controller).toBeNull();
+    expect(response.data.resultsData).toEqual({ hidden: true });
+  });
+
+  it("returns serializable task copies for BY_TYPE requests", async () => {
+    const appController = makeAppController();
+    const task = new Task(TaskTypes.coursesScan, { searchTerms: ["old phone number"] });
+    task.setId(8);
+    task.setStatus(TaskStatuses.COMPLETE);
+    appController.taskController.getTasksByType.mockReturnValue([task]);
+
+    const handler = new MessageHandler(appController);
+    const sendResponse = vi.fn();
+
+    await handler.handleSidePanelMessage(
+      new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Task.Request.BY_TYPE,
+        "tasks by type",
+        TaskTypes.coursesScan
+      ),
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    const response = sendResponse.mock.calls[0][0] as Message;
+    expect(response.type).toBe(MESSAGE_TYPE.Task.Response.BY_TYPE);
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]).toMatchObject({
+      id: 8,
+      type: TaskTypes.coursesScan,
+      status: TaskStatuses.COMPLETE,
+      settingsData: { searchTerms: ["old phone number"] },
+    });
+    expect(response.data[0].controller).toBeNull();
+  });
+
+  it("stops a task when the side panel sends a STOP request", async () => {
+    const appController = makeAppController();
+    const handler = new MessageHandler(appController);
+    const sendResponse = vi.fn();
+
+    await handler.handleSidePanelMessage(
+      new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Task.Request.STOP,
+        "stop task",
+        5
+      ),
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(appController.taskController.stopTask).toHaveBeenCalledWith(5);
+    const response = sendResponse.mock.calls[0][0] as Message;
+    expect(response.type).toBe(MESSAGE_TYPE.Task.Response.STOP);
+    expect(response.data).toBe(true);
+  });
+});

--- a/src/ServiceWorker/TabHandler.test.ts
+++ b/src/ServiceWorker/TabHandler.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TabHandler } from "./TabHandler";
+
+type AsyncListener = (...args: any[]) => void | Promise<void>;
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("TabHandler", () => {
+  let updatedListener: AsyncListener | undefined;
+  let removedListener: AsyncListener | undefined;
+  let activatedListener: AsyncListener | undefined;
+
+  beforeEach(() => {
+    updatedListener = undefined;
+    removedListener = undefined;
+    activatedListener = undefined;
+
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockReset();
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>).mockReset();
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    vi.mocked(chrome.tabs.onUpdated.addListener).mockImplementation((listener) => {
+      updatedListener = listener as AsyncListener;
+    });
+    vi.mocked(chrome.tabs.onRemoved.addListener).mockImplementation((listener) => {
+      removedListener = listener as AsyncListener;
+    });
+    vi.mocked(chrome.tabs.onActivated.addListener).mockImplementation((listener) => {
+      activatedListener = listener as AsyncListener;
+    });
+  });
+
+  it("discovers already-open Canvas tabs during init without needing a refresh", async () => {
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { id: 11, url: "https://school.instructure.com/courses/11", active: true } as chrome.tabs.Tab,
+      ])
+      .mockResolvedValueOnce([
+        { id: 11, url: "https://school.instructure.com/courses/11", active: true } as chrome.tabs.Tab,
+      ]);
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 11,
+      url: "https://school.instructure.com/courses/11",
+      active: true,
+    } as chrome.tabs.Tab);
+
+    const handler = new TabHandler();
+    handler.init();
+    await flushPromises();
+
+    expect(handler.hasTabs()).toBe(true);
+    expect(handler.getLastActiveTabId()).toBe(11);
+  });
+
+  it("tracks the last active valid Canvas tab", async () => {
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 22,
+      url: "https://school.instructure.com/courses/22/pages/home",
+      active: true,
+    } as chrome.tabs.Tab);
+    vi.mocked(chrome.tabs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 22, url: "https://school.instructure.com/courses/22/pages/home", active: true } as chrome.tabs.Tab,
+    ]);
+
+    const handler = new TabHandler();
+    handler.init();
+
+    await updatedListener?.(22, { status: "complete" }, { id: 22 } as chrome.tabs.Tab);
+    await flushPromises();
+    await activatedListener?.({ tabId: 22 });
+    await flushPromises();
+
+    expect(handler.getLastActiveTabId()).toBe(22);
+    expect(handler.getTabId()).toBe(22);
+  });
+
+  it("removes closed Canvas tabs from tracking", async () => {
+    vi.mocked(chrome.tabs.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 33,
+      url: "https://canvas.school.edu/courses/33",
+      active: true,
+    } as chrome.tabs.Tab);
+
+    const handler = new TabHandler();
+    handler.init();
+
+    await updatedListener?.(33, { status: "complete" }, { id: 33 } as chrome.tabs.Tab);
+    await flushPromises();
+    await removedListener?.(33, { isWindowClosing: false });
+    await flushPromises();
+
+    expect(handler.hasTabs()).toBe(false);
+    expect(handler.getLastActiveTabId()).toBeNull();
+  });
+});

--- a/src/ServiceWorker/TabHandler.ts
+++ b/src/ServiceWorker/TabHandler.ts
@@ -88,8 +88,23 @@ export class TabHandler
         if (newTab.id !== undefined && this.canvasTabs.includes(newTab.id)) this.lastActiveTabId = newTab.id;
     }
 
+    private async bootstrapTabs(): Promise<void>
+    {
+        const tabs = await chrome.tabs.query({});
+
+        for (let i = 0; i < tabs.length; i++)
+        {
+            const tabId = tabs[i]?.id;
+            if (tabId !== undefined) await this.updateValidTabs(tabId);
+        }
+
+        await this.updateActiveTab();
+    }
+
     init(): null
     {
+        this.bootstrapTabs();
+
         // Add listeners to track all valid tabs
         chrome.tabs.onUpdated.addListener(async (tabId: number, info: any, tab: chrome.tabs.Tab) => {
             this.updateValidTabs(tabId);

--- a/src/ServiceWorker/TaskController.test.ts
+++ b/src/ServiceWorker/TaskController.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TaskController from "./TaskController";
+import TaskRunner from "./TaskRunner";
+import Task, { TaskStatuses, TaskTypes } from "../shared/models/Task";
+
+describe("TaskController", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("assigns stable ids and preserves task settings when enqueued", () => {
+    const controller = new TaskController({
+      messageHandler: {
+        sendCanvasRequests: vi.fn(),
+      },
+    });
+
+    const firstTask = controller.enqueue({
+      type: TaskTypes.coursesScan,
+      settingsData: { searchTerms: ["retired faculty name"] },
+    });
+    const secondTask = controller.enqueue({
+      type: TaskTypes.coursesScan,
+      settingsData: { searchTerms: ["old phone number"] },
+    });
+
+    expect(firstTask.id).toBe(0);
+    expect(firstTask.settingsData).toEqual({ searchTerms: ["retired faculty name"] });
+    expect(secondTask.id).toBe(1);
+    expect(secondTask.settingsData).toEqual({ searchTerms: ["old phone number"] });
+  });
+
+  it("moves completed tasks from running to finished on update", () => {
+    const controller = new TaskController({
+      messageHandler: {
+        sendCanvasRequests: vi.fn(),
+      },
+    });
+    const task = controller.enqueue({ type: TaskTypes.coursesScan });
+
+    const runTaskSpy = vi.spyOn(TaskRunner, "runTask").mockImplementation((currentTask) => {
+      currentTask.setStatus(TaskStatuses.COMPLETE);
+      currentTask.setTimeFinished();
+      return true;
+    });
+
+    controller.update();
+
+    expect(runTaskSpy).toHaveBeenCalledTimes(1);
+    expect(controller.getTaskById(task.id)?.status).toBe(TaskStatuses.COMPLETE);
+    expect(controller.getTasksByType(TaskTypes.coursesScan)).toHaveLength(1);
+  });
+
+  it("defers a second courses scan until the first one is no longer running", () => {
+    const controller = new TaskController({
+      messageHandler: {
+        sendCanvasRequests: vi.fn(),
+      },
+    });
+    const firstTask = controller.enqueue({ type: TaskTypes.coursesScan });
+    const secondTask = controller.enqueue({ type: TaskTypes.coursesScan });
+
+    const runTaskSpy = vi.spyOn(TaskRunner, "runTask").mockImplementation((currentTask) => {
+      if (currentTask.id === firstTask.id) {
+        currentTask.setStatus(TaskStatuses.RUNNING);
+        return true;
+      }
+
+      currentTask.setStatus(TaskStatuses.COMPLETE);
+      return true;
+    });
+
+    controller.update();
+
+    expect(runTaskSpy).toHaveBeenCalledTimes(2);
+    expect(runTaskSpy.mock.calls[0][0].id).toBe(firstTask.id);
+    expect(runTaskSpy.mock.calls[1][0].id).toBe(secondTask.id);
+    expect(controller.getTaskById(firstTask.id)?.status).toBe(TaskStatuses.RUNNING);
+    expect(controller.getTaskById(secondTask.id)?.status).toBe(TaskStatuses.COMPLETE);
+  });
+
+  it("delegates stopTask to the running task controller", () => {
+    const controller = new TaskController({
+      messageHandler: {
+        sendCanvasRequests: vi.fn(),
+      },
+    });
+    const task = controller.enqueue({ type: TaskTypes.coursesScan });
+    const stop = vi.fn();
+
+    task.controller = { stop };
+
+    expect(controller.stopTask(task.id)).toBe(true);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when stopTask receives a missing id", () => {
+    const controller = new TaskController({
+      messageHandler: {
+        sendCanvasRequests: vi.fn(),
+      },
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(controller.stopTask(999)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith("No task for received task id");
+  });
+});

--- a/src/ServiceWorker/TaskController.test.ts
+++ b/src/ServiceWorker/TaskController.test.ts
@@ -72,10 +72,18 @@ describe("TaskController", () => {
 
     controller.update();
 
-    expect(runTaskSpy).toHaveBeenCalledTimes(2);
+    expect(runTaskSpy).toHaveBeenCalledTimes(1);
     expect(runTaskSpy.mock.calls[0][0].id).toBe(firstTask.id);
-    expect(runTaskSpy.mock.calls[1][0].id).toBe(secondTask.id);
     expect(controller.getTaskById(firstTask.id)?.status).toBe(TaskStatuses.RUNNING);
+    expect(controller.getTaskById(secondTask.id)?.status).toBe(TaskStatuses.NOT_STARTED);
+
+    const runningTask = controller.getTaskById(firstTask.id);
+    if (runningTask) runningTask.setStatus(TaskStatuses.COMPLETE);
+
+    controller.update();
+
+    expect(runTaskSpy).toHaveBeenCalledTimes(2);
+    expect(runTaskSpy.mock.calls[1][0].id).toBe(secondTask.id);
     expect(controller.getTaskById(secondTask.id)?.status).toBe(TaskStatuses.COMPLETE);
   });
 

--- a/src/ServiceWorker/TaskController.ts
+++ b/src/ServiceWorker/TaskController.ts
@@ -134,6 +134,7 @@ export default class TaskController
       )
       {
         this.newTasks.push(task);
+        continue;
       }
 
       const isRunning = TaskRunner.runTask(task, this.appController);

--- a/src/SidePanel/App.tsx
+++ b/src/SidePanel/App.tsx
@@ -29,6 +29,7 @@ export interface UserInfoValue {
   email: string;
   sis_user_id: string;
   lmsInstance: string;
+  timeZone: string;
 }
 
 interface MessageDataState {
@@ -59,6 +60,7 @@ export const UserInfoContext = createContext<UserInfoValue>({
   email: "",
   sis_user_id: "",
   lmsInstance: "",
+  timeZone: "",
 });
 
 function App() {
@@ -81,6 +83,7 @@ function App() {
     email: "",
     sis_user_id: "",
     lmsInstance: "",
+    timeZone: "",
   });
 
   useEffect(() => {
@@ -137,6 +140,7 @@ function App() {
         short_name: string;
         email: string;
         sis_user_id: string;
+        time_zone?: string | null;
       };
 
       setUserInfo(() => {
@@ -149,6 +153,7 @@ function App() {
           email: userData.email,
           sis_user_id: userData.sis_user_id,
           lmsInstance: appState.activeTab?.url ? new URL(appState.activeTab.url).origin : "",
+          timeZone: userData.time_zone ?? "",
         };
       });
     };

--- a/src/SidePanel/features/CoursesScanner/serializers/serializeCoursesScanResults.test.ts
+++ b/src/SidePanel/features/CoursesScanner/serializers/serializeCoursesScanResults.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import serializeCoursesScanResults from "./serializeCoursesScanResults";
+import { CourseItemTypes } from "../../../../shared/models/CourseItem";
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index];
+    const nextChar = line[index + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        current += '"';
+        index++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      values.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  values.push(current);
+  return values;
+}
+
+describe("serializeCoursesScanResults", () => {
+  it("serializes one row per matching item with repeated course fields", async () => {
+    const csv = await serializeCoursesScanResults([
+      {
+        id: 42,
+        name: "Course Alpha",
+        courseCode: "ALPHA-101",
+        sisCourseId: "SIS-42",
+        published: true,
+        url: "https://school.instructure.com/courses/42",
+        items: {
+          announcement: [],
+          assignment: [
+            {
+              type: CourseItemTypes.ASSIGNMENT,
+              id: 7,
+              name: "Essay 1",
+              url: "https://school.instructure.com/courses/42/assignments/7",
+              published: false,
+              matches: ["retired faculty name"],
+              previews: [["Contact ", "retired faculty name", " for help"]],
+            },
+          ],
+          courseNavLink: [],
+          discussion: [],
+          file: [],
+          moduleLink: [],
+          page: [
+            {
+              type: CourseItemTypes.PAGE,
+              id: 9,
+              name: "Homepage",
+              url: "https://school.instructure.com/courses/42/pages/homepage",
+              published: true,
+              matches: ["old phone number"],
+              previews: [["Call ", "old phone number", " to reach us"]],
+            },
+          ],
+          syllabus: [],
+        },
+      },
+    ]);
+
+    const rows = csv.split("\n").map(parseCsvLine);
+    expect(rows).toEqual([
+      ["course_id", "course_name", "course_code", "course_sis_id", "course_published", "course_url", "type", "id", "name", "url", "published", "matches"],
+      ["42", "Course Alpha", "ALPHA-101", "SIS-42", "TRUE", "https://school.instructure.com/courses/42", "assignment", "7", "Essay 1", "https://school.instructure.com/courses/42/assignments/7", "FALSE", "retired faculty name"],
+      ["42", "Course Alpha", "ALPHA-101", "SIS-42", "TRUE", "https://school.instructure.com/courses/42", "page", "9", "Homepage", "https://school.instructure.com/courses/42/pages/homepage", "TRUE", "old phone number"],
+    ]);
+  });
+
+  it("serializes the matches column as matched terms, not preview tuples", async () => {
+    const csv = await serializeCoursesScanResults([
+      {
+        id: 1,
+        name: "Course, \"Quoted\"",
+        courseCode: "CODE,1",
+        sisCourseId: null,
+        published: false,
+        url: null,
+        items: {
+          announcement: [],
+          assignment: [],
+          courseNavLink: [],
+          discussion: [],
+          file: [],
+          moduleLink: [],
+          page: [
+            {
+              type: CourseItemTypes.PAGE,
+              id: 9,
+              name: "Page, \"Home\"",
+              url: null,
+              published: true,
+              matches: ["term,one", 'term "two"'],
+              previews: [
+                ["before ", "term,one", " after"],
+                ["left ", 'term "two"', " right"],
+              ],
+            },
+          ],
+          syllabus: [],
+        },
+      },
+    ]);
+
+    const rows = csv.split("\n").map(parseCsvLine);
+    expect(rows[1]).toEqual([
+      "1",
+      'Course, "Quoted"',
+      "CODE,1",
+      "",
+      "FALSE",
+      "",
+      "page",
+      "9",
+      'Page, "Home"',
+      "",
+      "TRUE",
+      'term,one, term "two"',
+    ]);
+  });
+
+  it("uses N/A for syllabus item ids", async () => {
+    const csv = await serializeCoursesScanResults([
+      {
+        id: 9,
+        name: "Course",
+        courseCode: null,
+        sisCourseId: null,
+        published: true,
+        url: null,
+        items: {
+          announcement: [],
+          assignment: [],
+          courseNavLink: [],
+          discussion: [],
+          file: [],
+          moduleLink: [],
+          page: [],
+          syllabus: [
+            {
+              type: CourseItemTypes.SYLLABUS,
+              id: 999,
+              name: "Syllabus",
+              url: null,
+              published: true,
+              matches: ["obsolete office hours"],
+              previews: [["See ", "obsolete office hours", " in this section"]],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const rows = csv.split("\n").map(parseCsvLine);
+    expect(rows[1][7]).toBe("N/A");
+    expect(rows[1][11]).toBe("obsolete office hours");
+  });
+});

--- a/src/SidePanel/helpers/temporalDateTime.test.ts
+++ b/src/SidePanel/helpers/temporalDateTime.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCanvasDateTime,
+  hasNativeTemporal,
+  resolveEffectiveCanvasTimeZone,
+  shiftCanvasDateTimeByDays,
+} from "./temporalDateTime";
+
+describe("temporalDateTime", () => {
+  it("detects native Temporal support in the test runtime", () => {
+    expect(hasNativeTemporal()).toBe(true);
+  });
+
+  it("prefers a valid user timezone over the course timezone", () => {
+    expect(resolveEffectiveCanvasTimeZone("America/Denver", "America/Chicago")).toBe("America/Denver");
+  });
+
+  it("falls back to the course timezone when the user timezone is invalid", () => {
+    expect(resolveEffectiveCanvasTimeZone("Invalid/Timezone", "America/Chicago")).toBe("America/Chicago");
+  });
+
+  it("shifts a Canvas datetime forward by whole days while preserving local time", () => {
+    const shiftedDate = shiftCanvasDateTimeByDays("2026-03-10T17:00:00Z", "America/Denver", 3);
+
+    expect(shiftedDate).toBe("2026-03-13T17:00:00Z");
+    expect(formatCanvasDateTime(shiftedDate, "America/Denver")).toBe("Fri 3/13/2026, 11:00 AM");
+  });
+
+  it("shifts a Canvas datetime backward by whole days while preserving local time", () => {
+    const shiftedDate = shiftCanvasDateTimeByDays("2026-03-10T17:00:00Z", "America/Denver", -2);
+
+    expect(shiftedDate).toBe("2026-03-08T17:00:00Z");
+    expect(formatCanvasDateTime(shiftedDate, "America/Denver")).toBe("Sun 3/8/2026, 11:00 AM");
+  });
+});

--- a/src/SidePanel/helpers/temporalDateTime.ts
+++ b/src/SidePanel/helpers/temporalDateTime.ts
@@ -1,0 +1,105 @@
+type TemporalInstantLike = {
+  toZonedDateTimeISO: (timeZone: string) => TemporalZonedDateTimeLike;
+  toString: () => string;
+};
+
+type TemporalZonedDateTimeLike = {
+  year: number;
+  month: number;
+  day: number;
+  dayOfWeek: number;
+  hour: number;
+  minute: number;
+  add: (durationLike: { days?: number }) => TemporalZonedDateTimeLike;
+  toInstant: () => TemporalInstantLike;
+};
+
+type TemporalTimeZoneLike = unknown;
+
+type TemporalGlobalLike = {
+  Instant: {
+    from: (value: string) => TemporalInstantLike;
+  };
+  TimeZone?: {
+    from: (value: string) => TemporalTimeZoneLike;
+  };
+};
+
+function getTemporal(): TemporalGlobalLike | null {
+  const temporal = (globalThis as { Temporal?: TemporalGlobalLike }).Temporal;
+  return temporal ?? null;
+}
+
+export function hasNativeTemporal(): boolean {
+  const temporal = getTemporal();
+  return Boolean(temporal && temporal.Instant);
+}
+
+function normalizeTimeZone(value: string | null | undefined): string {
+  if (typeof value !== "string") return "";
+  return value.trim();
+}
+
+export function isValidTimeZone(timeZone: string | null | undefined): boolean {
+  const normalizedTimeZone = normalizeTimeZone(timeZone);
+  if (!normalizedTimeZone) return false;
+
+  const temporal = getTemporal();
+  if (!temporal) return false;
+
+  try {
+    if (temporal.TimeZone?.from) {
+      temporal.TimeZone.from(normalizedTimeZone);
+      return true;
+    }
+
+    const sampleInstant = temporal.Instant.from("2026-01-01T00:00:00Z");
+    sampleInstant.toZonedDateTimeISO(normalizedTimeZone);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveEffectiveCanvasTimeZone(userTimeZone: string | null | undefined, courseTimeZone: string | null | undefined): string {
+  const normalizedUserTimeZone = normalizeTimeZone(userTimeZone);
+  if (isValidTimeZone(normalizedUserTimeZone)) {
+    return normalizedUserTimeZone;
+  }
+
+  const normalizedCourseTimeZone = normalizeTimeZone(courseTimeZone);
+  if (isValidTimeZone(normalizedCourseTimeZone)) {
+    return normalizedCourseTimeZone;
+  }
+
+  return "";
+}
+
+function toZonedDateTime(dateIsoUtc: string, timeZone: string): TemporalZonedDateTimeLike {
+  const temporal = getTemporal();
+  if (!temporal) {
+    throw new Error("Temporal is not available in this browser.");
+  }
+
+  const instant = temporal.Instant.from(dateIsoUtc);
+  return instant.toZonedDateTimeISO(timeZone);
+}
+
+export function formatCanvasDateTime(dateIsoUtc: string, timeZone: string): string {
+  const zonedDateTime = toZonedDateTime(dateIsoUtc, timeZone);
+
+  const weekdayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const weekdayLabel = weekdayNames[zonedDateTime.dayOfWeek - 1] ?? "";
+  const hour12Value = zonedDateTime.hour % 12;
+  const displayHour = hour12Value === 0 ? 12 : hour12Value;
+  const displayMinute = String(zonedDateTime.minute).padStart(2, "0");
+  const meridiem = zonedDateTime.hour >= 12 ? "PM" : "AM";
+
+  return `${weekdayLabel} ${zonedDateTime.month}/${zonedDateTime.day}/${zonedDateTime.year}, ${displayHour}:${displayMinute} ${meridiem}`;
+}
+
+export function shiftCanvasDateTimeByDays(dateIsoUtc: string, timeZone: string, shiftDays: number): string {
+  const zonedDateTime = toZonedDateTime(dateIsoUtc, timeZone);
+  const shiftedDateTime = zonedDateTime.add({ days: shiftDays });
+  return shiftedDateTime.toInstant().toString();
+}

--- a/src/SidePanel/hooks/getActiveTabCourseId.test.ts
+++ b/src/SidePanel/hooks/getActiveTabCourseId.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import getActiveTabCourseId from "./getActiveTabCourseId";
+
+describe("getActiveTabCourseId", () => {
+  it("extracts the course id from a Canvas course page URL", () => {
+    expect(getActiveTabCourseId({ url: "https://school.instructure.com/courses/12345" } as chrome.tabs.Tab)).toBe("12345");
+  });
+
+  it("extracts the course id when the user is on a nested course resource", () => {
+    expect(getActiveTabCourseId({ url: "https://school.instructure.com/courses/9876/assignments/55" } as chrome.tabs.Tab)).toBe("9876");
+  });
+
+  it("returns null for a Canvas page that is not scoped to a course", () => {
+    expect(getActiveTabCourseId({ url: "https://school.instructure.com/calendar" } as chrome.tabs.Tab)).toBeNull();
+  });
+
+  it("returns null when there is no active tab", () => {
+    expect(getActiveTabCourseId(null as unknown as chrome.tabs.Tab)).toBeNull();
+  });
+});

--- a/src/SidePanel/hooks/useActiveCourseAnnouncements.ts
+++ b/src/SidePanel/hooks/useActiveCourseAnnouncements.ts
@@ -1,0 +1,148 @@
+import { useQuery } from "@tanstack/react-query";
+import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "../../shared/models/Message";
+import { CanvasRequest } from "../../shared/models/CanvasRequest";
+
+export interface AnnouncementDateItem {
+  id: number;
+  title: string;
+  delayedPostAt: string | null;
+}
+
+interface ActiveCourseAnnouncementsResult {
+  courseId: string;
+  courseName: string;
+  courseTimeZone: string;
+  announcements: AnnouncementDateItem[];
+}
+
+type QueryKey = ["active-course-announcements", { courseId: string }];
+
+type CanvasResponseItem = {
+  id: string;
+  status: number;
+  text: string;
+  link?: Record<string, string> | null;
+};
+
+type AnnouncementApiItem = {
+  id: number;
+  title: string;
+  delayed_post_at: string | null;
+};
+
+type CourseApiItem = {
+  name?: string;
+  time_zone?: string | null;
+};
+
+function getNextPage(link: string | undefined): number | null {
+  if (!link) return null;
+
+  try {
+    const nextUrl = new URL(link);
+    const page = nextUrl.searchParams.get("page");
+    if (!page) return null;
+
+    const pageNumber = Number.parseInt(page, 10);
+    if (Number.isNaN(pageNumber)) return null;
+
+    return pageNumber;
+  } catch {
+    return null;
+  }
+}
+
+async function sendCanvasRequests(requests: CanvasRequest[]): Promise<CanvasResponseItem[]> {
+  const msgRequest = new Message(
+    MESSAGE_TARGET.SERVICE_WORKER,
+    MESSAGE_SENDER.SIDE_PANEL,
+    MESSAGE_TYPE.Canvas.REQUESTS,
+    "Canvas requests",
+    requests
+  );
+
+  const msgResponse = await chrome.runtime.sendMessage(msgRequest) as { data?: CanvasResponseItem[] };
+  return msgResponse.data ?? [];
+}
+
+async function fetchAnnouncementsData({ queryKey }: { queryKey: QueryKey }): Promise<ActiveCourseAnnouncementsResult> {
+  const [_key, { courseId }] = queryKey;
+
+  if (!courseId) {
+    throw new Error("No active course found");
+  }
+
+  const courseRequest = new CanvasRequest(CanvasRequest.Get.Course, { courseId });
+  const courseResponse = await sendCanvasRequests([courseRequest]);
+
+  if (courseResponse.length === 0 || courseResponse[0].status >= 400) {
+    throw new Error("Could not load active course details");
+  }
+
+  let courseName = `Course ${courseId}`;
+  let courseTimeZone = "";
+
+  try {
+    const courseData = JSON.parse(courseResponse[0].text) as CourseApiItem;
+    if (typeof courseData.name === "string" && courseData.name.length > 0) {
+      courseName = courseData.name;
+    }
+
+    if (typeof courseData.time_zone === "string") {
+      courseTimeZone = courseData.time_zone;
+    }
+  } catch {
+    throw new Error("Could not parse active course details");
+  }
+
+  const announcements: AnnouncementDateItem[] = [];
+  let nextPage: number | null = 1;
+
+  while (nextPage !== null) {
+    const announcementRequest = new CanvasRequest(CanvasRequest.Get.Announcements, {
+      courseId,
+      page: nextPage,
+      perPage: 100,
+    });
+
+    const announcementResponse = await sendCanvasRequests([announcementRequest]);
+
+    if (announcementResponse.length === 0 || announcementResponse[0].status >= 400) {
+      throw new Error("Could not load announcements");
+    }
+
+    let pageItems: AnnouncementApiItem[] = [];
+
+    try {
+      pageItems = JSON.parse(announcementResponse[0].text) as AnnouncementApiItem[];
+    } catch {
+      throw new Error("Could not parse announcements data");
+    }
+
+    pageItems.forEach((item) => {
+      announcements.push({
+        id: item.id,
+        title: item.title,
+        delayedPostAt: item.delayed_post_at,
+      });
+    });
+
+    nextPage = getNextPage(announcementResponse[0].link?.next);
+  }
+
+  return {
+    courseId,
+    courseName,
+    courseTimeZone,
+    announcements,
+  };
+}
+
+export default function useActiveCourseAnnouncements(courseId: string | null) {
+  return useQuery({
+    queryKey: ["active-course-announcements", { courseId: courseId ?? "" }],
+    queryFn: fetchAnnouncementsData,
+    enabled: Boolean(courseId),
+    staleTime: 15_000,
+  });
+}

--- a/src/SidePanel/pages/AdjustDatesPage.test.tsx
+++ b/src/SidePanel/pages/AdjustDatesPage.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import AdjustDatesPage from "./AdjustDatesPage";
+import { AppStateContext, type AppStateValue, UserInfoContext, type UserInfoValue } from "../App";
+import { PageRouterContext } from "../router/PageRouter";
+import { ROUTER_PAGES } from "../types";
+import useActiveCourseAnnouncements from "../hooks/useActiveCourseAnnouncements";
+import { formatCanvasDateTime } from "../helpers/temporalDateTime";
+import { CANVAS_REQUEST_PUT } from "../../shared/models/CanvasRequest";
+import { MESSAGE_TYPE } from "../../shared/models/Message";
+
+vi.mock("../hooks/useActiveCourseAnnouncements", () => ({
+  default: vi.fn(),
+}));
+
+const mockedUseActiveCourseAnnouncements = vi.mocked(useActiveCourseAnnouncements);
+
+type AnnouncementQueryMock = ReturnType<typeof useActiveCourseAnnouncements>;
+
+function createAnnouncementsQueryResult(overrides: Partial<AnnouncementQueryMock> = {}): AnnouncementQueryMock {
+  return {
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    status: "success",
+    fetchStatus: "idle",
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    promise: Promise.resolve(undefined),
+    ...overrides,
+  } as unknown as AnnouncementQueryMock;
+}
+
+const appStateValue: AppStateValue = {
+  activeTab: { id: 51, url: "https://school.instructure.com/courses/51" } as chrome.tabs.Tab,
+  activeTabCourseId: "51",
+  hasTabs: true,
+  isAdmin: true,
+  isOnline: true,
+  timeChanged: 1,
+  timeUpdated: 1,
+};
+
+const userInfoValue: UserInfoValue = {
+  timeChecked: 1,
+  firstName: "Casey",
+  lastName: "Admin",
+  fullName: "Casey Admin",
+  shortName: "Casey",
+  email: "casey@example.com",
+  sis_user_id: "u-1",
+  lmsInstance: "https://school.instructure.com",
+  timeZone: "America/Denver",
+};
+
+function renderPage() {
+  return render(
+    <PageRouterContext.Provider value={{ page: ROUTER_PAGES.ADJUST_DATES, setPage: vi.fn() }}>
+      <AppStateContext.Provider value={appStateValue}>
+        <UserInfoContext.Provider value={userInfoValue}>
+          <AdjustDatesPage />
+        </UserInfoContext.Provider>
+      </AppStateContext.Provider>
+    </PageRouterContext.Provider>
+  );
+}
+
+describe("AdjustDatesPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockedUseActiveCourseAnnouncements.mockReturnValue(createAnnouncementsQueryResult({
+      data: {
+        courseId: "51",
+        courseName: "History 101",
+        courseTimeZone: "America/Denver",
+        announcements: [
+          {
+            id: 101,
+            title: "Welcome",
+            delayedPostAt: "2026-03-10T17:00:00Z",
+          },
+          {
+            id: 102,
+            title: "No schedule",
+            delayedPostAt: null,
+          },
+        ],
+      },
+      refetch: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.mocked(chrome.runtime.sendMessage as unknown as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("previews shifted announcement dates using the Temporal-backed helper", async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "3" } });
+    const announcementCheckboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(announcementCheckboxes[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Preview Changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Preview (1 update(s))")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(formatCanvasDateTime("2026-03-10T17:00:00Z", "America/Denver"))).toBeInTheDocument();
+    expect(screen.getByText(formatCanvasDateTime("2026-03-13T17:00:00Z", "America/Denver"))).toBeInTheDocument();
+    expect(screen.getByText(/1 announcement\(s\) do not have a scheduled posting date/)).toBeInTheDocument();
+  });
+
+  it("sends one announcement update request per preview item with shifted UTC dates", async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    mockedUseActiveCourseAnnouncements.mockReturnValue(createAnnouncementsQueryResult({
+      data: {
+        courseId: "51",
+        courseName: "History 101",
+        courseTimeZone: "America/Denver",
+        announcements: [
+          {
+            id: 101,
+            title: "Welcome",
+            delayedPostAt: "2026-03-10T17:00:00Z",
+          },
+          {
+            id: 103,
+            title: "Reminder",
+            delayedPostAt: "2026-03-11T17:00:00Z",
+          },
+        ],
+      },
+      refetch,
+    }));
+    const sendMessageSpy = vi.mocked(chrome.runtime.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [{ status: 200 }, { status: 200 }],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Select all scheduled" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview Changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply Changes" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply Changes" }));
+
+    await waitFor(() => {
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const requestMessage = sendMessageSpy.mock.calls[0][0];
+    expect(requestMessage.type).toBe(MESSAGE_TYPE.Canvas.REQUESTS);
+    expect(requestMessage.data).toHaveLength(2);
+    expect(requestMessage.data[0].type).toBe(CANVAS_REQUEST_PUT.Announcement);
+    expect(requestMessage.data[0].params).toEqual({
+      courseId: "51",
+      announcementId: 101,
+      delayedPostAt: "2026-03-12T17:00:00Z",
+    });
+    expect(requestMessage.data[1].params).toEqual({
+      courseId: "51",
+      announcementId: 103,
+      delayedPostAt: "2026-03-13T17:00:00Z",
+    });
+    expect(await screen.findByText("Successfully updated 2 announcement(s)." )).toBeInTheDocument();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports partial failures from the update API", async () => {
+    vi.mocked(chrome.runtime.sendMessage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [{ status: 200 }, { status: 500 }],
+    });
+    mockedUseActiveCourseAnnouncements.mockReturnValue(createAnnouncementsQueryResult({
+      data: {
+        courseId: "51",
+        courseName: "History 101",
+        courseTimeZone: "America/Denver",
+        announcements: [
+          {
+            id: 101,
+            title: "Welcome",
+            delayedPostAt: "2026-03-10T17:00:00Z",
+          },
+          {
+            id: 103,
+            title: "Reminder",
+            delayedPostAt: "2026-03-11T17:00:00Z",
+          },
+        ],
+      },
+      refetch: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    renderPage();
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Select all scheduled" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview Changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply Changes" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply Changes" }));
+
+    expect(await screen.findByText("Updated 1 announcement(s), but 1 failed.")).toBeInTheDocument();
+  });
+});

--- a/src/SidePanel/pages/AdjustDatesPage.tsx
+++ b/src/SidePanel/pages/AdjustDatesPage.tsx
@@ -1,0 +1,372 @@
+import Header from "../components/layout/Header";
+import Main from "../components/layout/Main";
+import Footer from "../components/layout/Footer";
+import IconButton from "../components/shared/buttons/IconButton";
+import { ArrowLeftIcon } from "@radix-ui/react-icons";
+import { useContext, useMemo, useState } from "react";
+import { PageRouterContext } from "../router/PageRouter";
+import { ROUTER_PAGES } from "../types";
+import { AppStateContext, UserInfoContext, type UserInfoValue } from "../App";
+import useActiveCourseAnnouncements, { type AnnouncementDateItem } from "../hooks/useActiveCourseAnnouncements";
+import ButtonPrimary from "../components/shared/buttons/ButtonPrimary";
+import { CanvasRequest } from "../../shared/models/CanvasRequest";
+import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "../../shared/models/Message";
+import {
+  formatCanvasDateTime,
+  hasNativeTemporal,
+  resolveEffectiveCanvasTimeZone,
+  shiftCanvasDateTimeByDays,
+} from "../helpers/temporalDateTime";
+
+type PreviewItem = {
+  id: number;
+  title: string;
+  oldDateUtc: string;
+  newDateUtc: string;
+};
+
+type CanvasResponseItem = {
+  status: number;
+};
+
+function AdjustDatesPage() {
+  const pageRouterState = useContext(PageRouterContext);
+  const appState = useContext(AppStateContext);
+  const userInfo = useContext(UserInfoContext) as UserInfoValue;
+
+  const courseId = appState.activeTabCourseId;
+
+  const { data, isLoading, isError, refetch } = useActiveCourseAnnouncements(courseId);
+
+  const [shiftDaysInput, setShiftDaysInput] = useState("0");
+  const [selectedAnnouncementIds, setSelectedAnnouncementIds] = useState<number[]>([]);
+  const [previewItems, setPreviewItems] = useState<PreviewItem[]>([]);
+  const [isApplying, setIsApplying] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const announcements = data?.announcements ?? [];
+  const courseTimeZone = data?.courseTimeZone ?? "";
+  const temporalAvailable = hasNativeTemporal();
+  const effectiveTimeZone = resolveEffectiveCanvasTimeZone(userInfo.timeZone, courseTimeZone);
+  const canUseTimeLogic = temporalAvailable && Boolean(effectiveTimeZone);
+  const requiresTimeZoneNotice = Boolean(userInfo.timeZone) && Boolean(courseTimeZone) && userInfo.timeZone !== courseTimeZone;
+
+  const selectableAnnouncements = useMemo(() => {
+    return announcements.filter((item) => item.delayedPostAt !== null);
+  }, [announcements]);
+
+  const unselectableCount = announcements.length - selectableAnnouncements.length;
+
+  function formatDateForDisplay(dateIso: string): string {
+    if (!effectiveTimeZone) return "Unavailable";
+
+    try {
+      return formatCanvasDateTime(dateIso, effectiveTimeZone);
+    } catch {
+      return "Unavailable";
+    }
+  }
+
+  function handleToggleAnnouncement(itemId: number): void {
+    setStatusMessage(null);
+    setPreviewItems([]);
+
+    setSelectedAnnouncementIds((current) => {
+      if (current.includes(itemId)) {
+        return current.filter((id) => id !== itemId);
+      }
+
+      return [...current, itemId];
+    });
+  }
+
+  function handleSelectAll(): void {
+    setStatusMessage(null);
+    setPreviewItems([]);
+    setSelectedAnnouncementIds(selectableAnnouncements.map((item) => item.id));
+  }
+
+  function handleClearSelection(): void {
+    setStatusMessage(null);
+    setPreviewItems([]);
+    setSelectedAnnouncementIds([]);
+  }
+
+  function createPreviewItems(): PreviewItem[] {
+    if (!temporalAvailable) {
+      throw new Error("This browser does not support Temporal.");
+    }
+
+    if (!effectiveTimeZone) {
+      throw new Error("Canvas display timezone is unavailable for this course/user.");
+    }
+
+    const shiftDays = Number.parseInt(shiftDaysInput, 10);
+
+    if (Number.isNaN(shiftDays)) {
+      throw new Error("Shift days must be a whole number");
+    }
+
+    const announcementsMap = new Map<number, AnnouncementDateItem>(
+      announcements.map((item) => [item.id, item])
+    );
+
+    const selectedItems = selectedAnnouncementIds
+      .map((id) => announcementsMap.get(id))
+      .filter((item): item is AnnouncementDateItem => Boolean(item && item.delayedPostAt));
+
+    return selectedItems.map((item) => {
+      const oldDateUtc = item.delayedPostAt as string;
+      const newDateUtc = shiftCanvasDateTimeByDays(oldDateUtc, effectiveTimeZone, shiftDays);
+
+      return {
+        id: item.id,
+        title: item.title,
+        oldDateUtc,
+        newDateUtc,
+      };
+    });
+  }
+
+  function handlePreview(): void {
+    setStatusMessage(null);
+
+    try {
+      const nextPreviewItems = createPreviewItems();
+
+      if (nextPreviewItems.length === 0) {
+        setPreviewItems([]);
+        setStatusMessage("Select at least one scheduled announcement before previewing.");
+        return;
+      }
+
+      setPreviewItems(nextPreviewItems);
+    } catch (error) {
+      setPreviewItems([]);
+      if (error instanceof Error) {
+        setStatusMessage(error.message);
+        return;
+      }
+
+      setStatusMessage("Could not generate preview.");
+    }
+  }
+
+  async function handleApply(): Promise<void> {
+    if (!data?.courseId || previewItems.length === 0) {
+      setStatusMessage("Preview changes before applying updates.");
+      return;
+    }
+
+    if (!canUseTimeLogic) {
+      setStatusMessage("Cannot apply updates until Canvas display timezone is available.");
+      return;
+    }
+
+    setIsApplying(true);
+    setStatusMessage(null);
+
+    const requests = previewItems.map((item) => new CanvasRequest(CanvasRequest.Put.Announcement, {
+      courseId: data.courseId,
+      announcementId: item.id,
+      delayedPostAt: item.newDateUtc,
+    }));
+
+    try {
+      const requestMessage = new Message(
+        MESSAGE_TARGET.SERVICE_WORKER,
+        MESSAGE_SENDER.SIDE_PANEL,
+        MESSAGE_TYPE.Canvas.REQUESTS,
+        "Adjust announcement dates",
+        requests
+      );
+
+      const response = await chrome.runtime.sendMessage(requestMessage) as { data?: CanvasResponseItem[] };
+      const responseItems = response.data ?? [];
+
+      if (responseItems.length !== requests.length) {
+        throw new Error("Unexpected response while applying updates");
+      }
+
+      const failedUpdates = responseItems.filter((item) => item.status >= 400).length;
+      const successfulUpdates = responseItems.length - failedUpdates;
+
+      if (failedUpdates > 0) {
+        setStatusMessage(`Updated ${successfulUpdates} announcement(s), but ${failedUpdates} failed.`);
+      } else {
+        setStatusMessage(`Successfully updated ${successfulUpdates} announcement(s).`);
+      }
+
+      setPreviewItems([]);
+      setSelectedAnnouncementIds([]);
+      await refetch();
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatusMessage(error.message);
+      } else {
+        setStatusMessage("Could not apply updates.");
+      }
+    } finally {
+      setIsApplying(false);
+    }
+  }
+
+  const parsedShiftDays = Number.parseInt(shiftDaysInput, 10);
+  const hasNonZeroShiftDays = !Number.isNaN(parsedShiftDays) && parsedShiftDays !== 0;
+  const canPreview = selectedAnnouncementIds.length > 0 && canUseTimeLogic && hasNonZeroShiftDays;
+  const canApply = previewItems.length > 0 && !isApplying && canUseTimeLogic;
+  const isInApplyStep = previewItems.length > 0;
+
+  return (
+    <>
+      <Header>
+        <IconButton animated={true} onClick={() => pageRouterState.setPage(ROUTER_PAGES.MENU)}>
+          <ArrowLeftIcon className="w-8 h-8" />
+        </IconButton>
+      </Header>
+      <Main>
+        <div className="justify-self-center self-start p-4 w-full grid grid-cols-1 grid-flow-row justify-items-center">
+          <div className="grid grid-cols-1 grid-flow-row gap-3 justify-items-start w-full max-w-lg">
+            <div className="w-full p-3 bg-gray-100 rounded-sm border border-gray-200">
+              <h2 className="text-base font-bold text-gray-800">Adjust Announcement Dates</h2>
+              <p className="text-sm text-gray-700 mt-1">Active course: <span className="font-bold">{data?.courseName ?? (courseId ? "Loading..." : "No active course")}</span></p>
+              <p className="text-xs text-gray-500">Course ID: {courseId ?? "No course tab detected"}</p>
+              <p className="text-xs text-gray-600 mt-1">Display timezone: {effectiveTimeZone || "Unavailable"}</p>
+              {requiresTimeZoneNotice && <p className="text-xs text-gray-600">Course timezone: {courseTimeZone}</p>}
+            </div>
+
+            {isLoading && <p className="text-sm">Loading announcements...</p>}
+
+            {isError && (
+              <div className="w-full p-3 bg-red-100 text-red-700 rounded-sm">
+                Could not load announcements for the active course.
+              </div>
+            )}
+
+            {!isLoading && !isError && (
+              <>
+                {!courseId && (
+                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
+                    Open a Canvas course tab first, then reopen this page.
+                  </div>
+                )}
+
+                {!temporalAvailable && (
+                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
+                    This browser does not support native Temporal yet. Adjust Dates is unavailable.
+                  </div>
+                )}
+
+                {temporalAvailable && courseId && !effectiveTimeZone && (
+                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
+                    Canvas display timezone is unavailable for this course/user. Cannot preview or apply changes.
+                  </div>
+                )}
+
+                {courseId && (
+                  <>
+                    <div className="w-full p-3 bg-white rounded-sm shadow-sm border border-gray-200">
+                      <p className="text-sm font-bold text-gray-700">Shift selected dates by days</p>
+                      <input
+                        className="mt-2 w-full px-2 py-1 bg-white text-base text-gray-700 rounded-sm shadow-inner border-2 border-gray-200 outline-blue-500"
+                        type="number"
+                        step={1}
+                        value={shiftDaysInput}
+                        onChange={(event) => {
+                          setShiftDaysInput(event.target.value);
+                          setStatusMessage(null);
+                          setPreviewItems([]);
+                        }}
+                      />
+                      <p className="text-xs text-gray-500 mt-1">Use negative values to move dates earlier.</p>
+                      {!hasNonZeroShiftDays && (
+                        <p className="text-xs text-gray-500 mt-1">Enter a non-zero day shift to preview changes.</p>
+                      )}
+                    </div>
+
+                    <div className="w-full p-3 bg-white rounded-sm shadow-sm border border-gray-200">
+                      <div className="flex items-center justify-between gap-2 mb-2">
+                        <p className="text-sm font-bold text-gray-700">Announcements ({announcements.length})</p>
+                        <div className="flex items-center gap-2">
+                          <button className="text-xs text-blue-600 hover:text-blue-400" onClick={handleSelectAll} type="button">Select all scheduled</button>
+                          <button className="text-xs text-gray-500 hover:text-gray-700" onClick={handleClearSelection} type="button">Clear</button>
+                        </div>
+                      </div>
+
+                      {unselectableCount > 0 && (
+                        <p className="text-xs text-gray-500 mb-2">{unselectableCount} announcement(s) do not have a scheduled posting date and cannot be shifted.</p>
+                      )}
+
+                      <div className="max-h-56 overflow-y-auto border border-gray-100 rounded-sm">
+                        {announcements.length === 0 && <p className="text-sm p-2">No announcements found.</p>}
+
+                        {announcements.map((item) => {
+                          const isSelectable = item.delayedPostAt !== null;
+                          const checked = selectedAnnouncementIds.includes(item.id);
+
+                          return (
+                            <label key={item.id} className={`flex gap-2 p-2 border-b border-gray-100 ${isSelectable ? "cursor-pointer" : "opacity-60"}`}>
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                disabled={!isSelectable}
+                                onChange={() => handleToggleAnnouncement(item.id)}
+                              />
+                              <span className="text-sm grow">
+                                <span className="font-medium block">{item.title}</span>
+                                <span className="text-xs text-gray-500">
+                                  {item.delayedPostAt ? `Scheduled: ${formatDateForDisplay(item.delayedPostAt)}` : "No scheduled posting date"}
+                                </span>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+
+                    <div className="w-full grid grid-cols-1 gap-2">
+                      {!isInApplyStep && (
+                        <ButtonPrimary onClick={handlePreview} disabled={!canPreview}>Preview Changes</ButtonPrimary>
+                      )}
+
+                      {isInApplyStep && (
+                        <ButtonPrimary onClick={handleApply} disabled={!canApply} isLoading={isApplying}>Apply Changes</ButtonPrimary>
+                      )}
+                    </div>
+
+                    {previewItems.length > 0 && (
+                      <div className="w-full p-3 bg-blue-50 rounded-sm border border-blue-100">
+                        <p className="text-sm font-bold text-blue-700 mb-2">Preview ({previewItems.length} update(s))</p>
+                        <div className="max-h-40 overflow-y-auto">
+                          {previewItems.map((item) => (
+                            <div key={item.id} className="text-xs text-blue-800 mb-2">
+                              <p className="font-semibold">{item.title}</p>
+                              <div className="flex items-center gap-2">
+                                <span className="min-w-[13rem] text-right">{formatDateForDisplay(item.oldDateUtc)}</span>
+                                <span>→</span>
+                                <span className="min-w-[13rem] text-left">{formatDateForDisplay(item.newDateUtc)}</span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {statusMessage && (
+                      <div className="w-full p-2 rounded-sm bg-gray-100 text-sm text-gray-700">
+                        {statusMessage}
+                      </div>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </Main>
+      <Footer />
+    </>
+  );
+}
+
+export default AdjustDatesPage;

--- a/src/SidePanel/pages/AdjustDatesPage.tsx
+++ b/src/SidePanel/pages/AdjustDatesPage.tsx
@@ -9,6 +9,7 @@ import { ROUTER_PAGES } from "../types";
 import { AppStateContext, UserInfoContext, type UserInfoValue } from "../App";
 import useActiveCourseAnnouncements, { type AnnouncementDateItem } from "../hooks/useActiveCourseAnnouncements";
 import ButtonPrimary from "../components/shared/buttons/ButtonPrimary";
+import PrimaryCard from "../components/shared/cards/PrimaryCard";
 import { CanvasRequest } from "../../shared/models/CanvasRequest";
 import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "../../shared/models/Message";
 import {
@@ -35,7 +36,6 @@ function AdjustDatesPage() {
   const userInfo = useContext(UserInfoContext) as UserInfoValue;
 
   const courseId = appState.activeTabCourseId;
-
   const { data, isLoading, isError, refetch } = useActiveCourseAnnouncements(courseId);
 
   const [shiftDaysInput, setShiftDaysInput] = useState("0");
@@ -225,142 +225,141 @@ function AdjustDatesPage() {
         </IconButton>
       </Header>
       <Main>
-        <div className="justify-self-center self-start p-4 w-full grid grid-cols-1 grid-flow-row justify-items-center">
-          <div className="grid grid-cols-1 grid-flow-row gap-3 justify-items-start w-full max-w-lg">
-            <div className="w-full p-3 bg-gray-100 rounded-sm border border-gray-200">
-              <h2 className="text-base font-bold text-gray-800">Adjust Announcement Dates</h2>
-              <p className="text-sm text-gray-700 mt-1">Active course: <span className="font-bold">{data?.courseName ?? (courseId ? "Loading..." : "No active course")}</span></p>
-              <p className="text-xs text-gray-500">Course ID: {courseId ?? "No course tab detected"}</p>
-              <p className="text-xs text-gray-600 mt-1">Display timezone: {effectiveTimeZone || "Unavailable"}</p>
-              {requiresTimeZoneNotice && <p className="text-xs text-gray-600">Course timezone: {courseTimeZone}</p>}
+        <div className="self-start w-full p-4 flex justify-center">
+          <div className="w-full max-w-5xl grid grid-cols-1 gap-4">
+            <PrimaryCard fixedWidth={false} className="w-full" minHeight={false}>
+            <div className="grid grid-cols-1 grid-flow-row start justify-start content-start gap-2">
+              <h3 className="text-gray-700 text-xl text-center">Adjust Announcement Dates</h3>
+              <p className="text-sm text-gray-700"><span className="font-bold">Active Course:</span> {data?.courseName ?? (courseId ? "Loading..." : "No active course")}</p>
+              <p className="text-sm text-gray-700"><span className="font-bold">Course ID:</span> {courseId ?? "No course tab detected"}</p>
+              <p className="text-sm text-gray-700"><span className="font-bold">Display Timezone:</span> {effectiveTimeZone || "Unavailable"}</p>
+              {requiresTimeZoneNotice && <p className="text-sm text-gray-700"><span className="font-bold">Course Timezone:</span> {courseTimeZone}</p>}
+
+              {isLoading && <p className="text-sm text-gray-700">Loading announcements...</p>}
+
+              {isError && (
+                <p className="text-sm text-red-700">Could not load announcements for the active course.</p>
+              )}
+
+              {!courseId && (
+                <p className="text-sm text-yellow-700">Open a Canvas course tab first, then reopen this page.</p>
+              )}
+
+              {!temporalAvailable && (
+                <p className="text-sm text-yellow-700">This browser does not support native Temporal yet. Adjust Dates is unavailable.</p>
+              )}
+
+              {!isLoading && temporalAvailable && courseId && !effectiveTimeZone && (
+                <p className="text-sm text-yellow-700">Canvas display timezone is unavailable for this course/user. Cannot preview or apply changes.</p>
+              )}
             </div>
+          </PrimaryCard>
 
-            {isLoading && <p className="text-sm">Loading announcements...</p>}
+          {courseId && (
+            <>
+              <PrimaryCard fixedWidth={false} className="w-full" minHeight={false}>
+                <div className="grid grid-cols-1 grid-flow-row start justify-start content-start gap-2">
+                  <h3 className="text-gray-700 text-xl text-center">Shift Settings</h3>
+                  <input
+                    className="w-full px-2 py-1 bg-white text-base text-gray-700 rounded-sm shadow-inner border-2 border-gray-200 outline-blue-500"
+                    type="number"
+                    step={1}
+                    value={shiftDaysInput}
+                    onChange={(event) => {
+                      setShiftDaysInput(event.target.value);
+                      setStatusMessage(null);
+                      setPreviewItems([]);
+                    }}
+                  />
+                  <p className="text-sm text-gray-700">Use negative values to move dates earlier.</p>
+                  {!hasNonZeroShiftDays && (
+                    <p className="text-sm text-gray-700">Enter a non-zero day shift to preview changes.</p>
+                  )}
+                </div>
+              </PrimaryCard>
 
-            {isError && (
-              <div className="w-full p-3 bg-red-100 text-red-700 rounded-sm">
-                Could not load announcements for the active course.
-              </div>
-            )}
-
-            {!isLoading && !isError && (
-              <>
-                {!courseId && (
-                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
-                    Open a Canvas course tab first, then reopen this page.
+              <PrimaryCard fixedWidth={false} className="w-full" minHeight={false}>
+                <div className="grid grid-cols-1 grid-flow-row start justify-start content-start gap-2">
+                  <h3 className="text-gray-700 text-xl text-center">Announcements ({announcements.length})</h3>
+                  <div className="flex items-center justify-center gap-2">
+                    <button className="text-xs text-blue-600 hover:text-blue-400" onClick={handleSelectAll} type="button">Select all scheduled</button>
+                    <button className="text-xs text-gray-500 hover:text-gray-700" onClick={handleClearSelection} type="button">Clear</button>
                   </div>
-                )}
 
-                {!temporalAvailable && (
-                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
-                    This browser does not support native Temporal yet. Adjust Dates is unavailable.
+                  {unselectableCount > 0 && (
+                    <p className="text-xs text-gray-500">{unselectableCount} announcement(s) do not have a scheduled posting date and cannot be shifted.</p>
+                  )}
+
+                  <div className="max-h-56 overflow-y-auto border border-gray-100 rounded-sm bg-white">
+                    {announcements.length === 0 && <p className="text-sm p-2">No announcements found.</p>}
+
+                    {announcements.map((item) => {
+                      const isSelectable = item.delayedPostAt !== null;
+                      const checked = selectedAnnouncementIds.includes(item.id);
+
+                      return (
+                        <label key={item.id} className={`flex gap-2 p-2 border-b border-gray-100 ${isSelectable ? "cursor-pointer" : "opacity-60"}`}>
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={!isSelectable}
+                            onChange={() => handleToggleAnnouncement(item.id)}
+                          />
+                          <span className="text-sm grow">
+                            <span className="font-medium block">{item.title}</span>
+                            <span className="text-xs text-gray-500">
+                              {item.delayedPostAt ? `Scheduled: ${formatDateForDisplay(item.delayedPostAt)}` : "No scheduled posting date"}
+                            </span>
+                          </span>
+                        </label>
+                      );
+                    })}
                   </div>
-                )}
+                </div>
+              </PrimaryCard>
 
-                {temporalAvailable && courseId && !effectiveTimeZone && (
-                  <div className="w-full p-3 bg-yellow-100 rounded-sm border border-yellow-200 text-sm text-yellow-800">
-                    Canvas display timezone is unavailable for this course/user. Cannot preview or apply changes.
-                  </div>
-                )}
+              <PrimaryCard fixedWidth={false} className="w-full" minHeight={false}>
+                <div className="grid grid-cols-1 grid-flow-row start justify-start content-start gap-2">
+                  <h3 className="text-gray-700 text-xl text-center">Review & Apply</h3>
 
-                {courseId && (
-                  <>
-                    <div className="w-full p-3 bg-white rounded-sm shadow-sm border border-gray-200">
-                      <p className="text-sm font-bold text-gray-700">Shift selected dates by days</p>
-                      <input
-                        className="mt-2 w-full px-2 py-1 bg-white text-base text-gray-700 rounded-sm shadow-inner border-2 border-gray-200 outline-blue-500"
-                        type="number"
-                        step={1}
-                        value={shiftDaysInput}
-                        onChange={(event) => {
-                          setShiftDaysInput(event.target.value);
-                          setStatusMessage(null);
-                          setPreviewItems([]);
-                        }}
-                      />
-                      <p className="text-xs text-gray-500 mt-1">Use negative values to move dates earlier.</p>
-                      {!hasNonZeroShiftDays && (
-                        <p className="text-xs text-gray-500 mt-1">Enter a non-zero day shift to preview changes.</p>
-                      )}
-                    </div>
+                  {!isInApplyStep && (
+                    <ButtonPrimary onClick={handlePreview} disabled={!canPreview}>Preview Changes</ButtonPrimary>
+                  )}
 
-                    <div className="w-full p-3 bg-white rounded-sm shadow-sm border border-gray-200">
-                      <div className="flex items-center justify-between gap-2 mb-2">
-                        <p className="text-sm font-bold text-gray-700">Announcements ({announcements.length})</p>
-                        <div className="flex items-center gap-2">
-                          <button className="text-xs text-blue-600 hover:text-blue-400" onClick={handleSelectAll} type="button">Select all scheduled</button>
-                          <button className="text-xs text-gray-500 hover:text-gray-700" onClick={handleClearSelection} type="button">Clear</button>
-                        </div>
+                  {isInApplyStep && (
+                    <ButtonPrimary onClick={handleApply} disabled={!canApply} isLoading={isApplying}>Apply Changes</ButtonPrimary>
+                  )}
+
+                  {previewItems.length > 0 && (
+                    <div className="w-full p-2 bg-blue-50 rounded-sm border border-blue-100">
+                      <p className="text-sm font-bold text-blue-700 mb-2">Preview ({previewItems.length} update(s))</p>
+                      <div className="text-sm text-blue-700 grid grid-cols-7 gap-2 mb-2">
+                        <span className="col-span-3 text-right font-semibold">Current</span>
+                        <span className="text-center">→</span>
+                        <span className="col-span-3 text-left font-semibold">New</span>
                       </div>
-
-                      {unselectableCount > 0 && (
-                        <p className="text-xs text-gray-500 mb-2">{unselectableCount} announcement(s) do not have a scheduled posting date and cannot be shifted.</p>
-                      )}
-
-                      <div className="max-h-56 overflow-y-auto border border-gray-100 rounded-sm">
-                        {announcements.length === 0 && <p className="text-sm p-2">No announcements found.</p>}
-
-                        {announcements.map((item) => {
-                          const isSelectable = item.delayedPostAt !== null;
-                          const checked = selectedAnnouncementIds.includes(item.id);
-
-                          return (
-                            <label key={item.id} className={`flex gap-2 p-2 border-b border-gray-100 ${isSelectable ? "cursor-pointer" : "opacity-60"}`}>
-                              <input
-                                type="checkbox"
-                                checked={checked}
-                                disabled={!isSelectable}
-                                onChange={() => handleToggleAnnouncement(item.id)}
-                              />
-                              <span className="text-sm grow">
-                                <span className="font-medium block">{item.title}</span>
-                                <span className="text-xs text-gray-500">
-                                  {item.delayedPostAt ? `Scheduled: ${formatDateForDisplay(item.delayedPostAt)}` : "No scheduled posting date"}
-                                </span>
-                              </span>
-                            </label>
-                          );
-                        })}
-                      </div>
-                    </div>
-
-                    <div className="w-full grid grid-cols-1 gap-2">
-                      {!isInApplyStep && (
-                        <ButtonPrimary onClick={handlePreview} disabled={!canPreview}>Preview Changes</ButtonPrimary>
-                      )}
-
-                      {isInApplyStep && (
-                        <ButtonPrimary onClick={handleApply} disabled={!canApply} isLoading={isApplying}>Apply Changes</ButtonPrimary>
-                      )}
-                    </div>
-
-                    {previewItems.length > 0 && (
-                      <div className="w-full p-3 bg-blue-50 rounded-sm border border-blue-100">
-                        <p className="text-sm font-bold text-blue-700 mb-2">Preview ({previewItems.length} update(s))</p>
-                        <div className="max-h-40 overflow-y-auto">
-                          {previewItems.map((item) => (
-                            <div key={item.id} className="text-xs text-blue-800 mb-2">
-                              <p className="font-semibold">{item.title}</p>
-                              <div className="flex items-center gap-2">
-                                <span className="min-w-[13rem] text-right">{formatDateForDisplay(item.oldDateUtc)}</span>
-                                <span>→</span>
-                                <span className="min-w-[13rem] text-left">{formatDateForDisplay(item.newDateUtc)}</span>
-                              </div>
+                      <div>
+                        {previewItems.map((item) => (
+                          <div key={item.id} className="text-xs text-blue-800 mb-2">
+                            <p className="font-semibold">{item.title}</p>
+                            <div className="grid grid-cols-7 gap-2">
+                              <span className="col-span-3 pl-4">{formatDateForDisplay(item.oldDateUtc)}</span>
+                              <span className="text-center">→</span>
+                              <span className="col-span-3">{formatDateForDisplay(item.newDateUtc)}</span>
                             </div>
-                          ))}
-                        </div>
+                          </div>
+                        ))}
                       </div>
-                    )}
+                    </div>
+                  )}
 
-                    {statusMessage && (
-                      <div className="w-full p-2 rounded-sm bg-gray-100 text-sm text-gray-700">
-                        {statusMessage}
-                      </div>
-                    )}
-                  </>
-                )}
-              </>
-            )}
+                  {statusMessage && (
+                    <p className="text-sm text-gray-700">{statusMessage}</p>
+                  )}
+                </div>
+              </PrimaryCard>
+            </>
+          )}
           </div>
         </div>
       </Main>

--- a/src/SidePanel/pages/AdjustDatesPage.tsx
+++ b/src/SidePanel/pages/AdjustDatesPage.tsx
@@ -10,7 +10,7 @@ import { AppStateContext, UserInfoContext, type UserInfoValue } from "../App";
 import useActiveCourseAnnouncements, { type AnnouncementDateItem } from "../hooks/useActiveCourseAnnouncements";
 import ButtonPrimary from "../components/shared/buttons/ButtonPrimary";
 import PrimaryCard from "../components/shared/cards/PrimaryCard";
-import { CanvasRequest } from "../../shared/models/CanvasRequest";
+import { CANVAS_REQUEST_PUT, CanvasRequest } from "../../shared/models/CanvasRequest";
 import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "../../shared/models/Message";
 import {
   formatCanvasDateTime,
@@ -166,7 +166,7 @@ function AdjustDatesPage() {
     setIsApplying(true);
     setStatusMessage(null);
 
-    const requests = previewItems.map((item) => new CanvasRequest(CanvasRequest.Put.Announcement, {
+    const requests = previewItems.map((item) => new CanvasRequest(CANVAS_REQUEST_PUT.Announcement, {
       courseId: data.courseId,
       announcementId: item.id,
       delayedPostAt: item.newDateUtc,
@@ -259,7 +259,7 @@ function AdjustDatesPage() {
             <>
               <PrimaryCard fixedWidth={false} className="w-full" minHeight={false}>
                 <div className="grid grid-cols-1 grid-flow-row start justify-start content-start gap-2">
-                  <h3 className="text-gray-700 text-xl text-center">Shift Settings</h3>
+                  <h3 className="text-gray-700 text-xl text-center">Adjust by Days</h3>
                   <input
                     className="w-full px-2 py-1 bg-white text-base text-gray-700 rounded-sm shadow-inner border-2 border-gray-200 outline-blue-500"
                     type="number"

--- a/src/SidePanel/pages/MenuPage.tsx
+++ b/src/SidePanel/pages/MenuPage.tsx
@@ -2,7 +2,7 @@ import Header from "../components/layout/Header";
 import Footer from "../components/layout/Footer";
 import { AppStateContext, UserInfoContext, type AppStateValue, type UserInfoValue } from "../App";
 import { useContext, useState } from "react";
-import { MagnifyingGlassIcon, RocketIcon, BackpackIcon, InfoCircledIcon } from "@radix-ui/react-icons";
+import { MagnifyingGlassIcon, CalendarIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import Main from "../components/layout/Main";
 import { PageRouterContext } from "../router/PageRouter";
 import MenuButton from "../components/shared/buttons/MenuButton";
@@ -48,6 +48,11 @@ function MenuPage() {
             <MenuButton onClick={() => pageRouterState.setPage(ROUTER_PAGES.COURSES_SCANNER)}>
               <MagnifyingGlassIcon />
               Search Courses
+            </MenuButton>
+
+            <MenuButton onClick={() => pageRouterState.setPage(ROUTER_PAGES.ADJUST_DATES)}>
+              <CalendarIcon />
+              Adjust Dates
             </MenuButton>
             {/*Admin only buttons go below this line*/}
             {/*{appState.isAdmin && <MenuButton onClick={() => pageRouterState.setPage(ROUTER_PAGES.EXTERNAL_TOOLS)}>*/}

--- a/src/SidePanel/router/PageRouter.tsx
+++ b/src/SidePanel/router/PageRouter.tsx
@@ -3,6 +3,7 @@ import LoadingPage from "../pages/LoadingPage";
 import MenuPage from "../pages/MenuPage";
 import ErrorPage from "../pages/ErrorPage";
 import CoursesScannerPage from "../pages/CoursesScannerPage";
+import AdjustDatesPage from "../pages/AdjustDatesPage";
 import ExternalToolsPage from "../pages/ExternalToolsPage";
 import AdminToolsPage from "../pages/AdminToolsPage";
 import AboutPage from "../pages/AboutPage";
@@ -31,6 +32,9 @@ function PageRouter() {
 
       case ROUTER_PAGES.COURSES_SCANNER:
         return <CoursesScannerPage />;
+
+      case ROUTER_PAGES.ADJUST_DATES:
+        return <AdjustDatesPage />;
 
       case ROUTER_PAGES.EXTERNAL_TOOLS:
         return <ExternalToolsPage />;

--- a/src/SidePanel/types/router-page.ts
+++ b/src/SidePanel/types/router-page.ts
@@ -1,11 +1,12 @@
 export const ROUTER_PAGES = {
-   ERROR: "error",
-   LOADING: "loading",
-   MENU: "menu",
-   ABOUT: "about",
-   COURSES_SCANNER: "courses_scanner",
-   ADMIN_TOOLS: "admin_tools",
-   EXTERNAL_TOOLS: "external_tools",
-} as const
+  ERROR: "error",
+  LOADING: "loading",
+  MENU: "menu",
+  ABOUT: "about",
+  COURSES_SCANNER: "courses_scanner",
+  ADJUST_DATES: "adjust_dates",
+  ADMIN_TOOLS: "admin_tools",
+  EXTERNAL_TOOLS: "external_tools",
+} as const;
 
-export type RouterPage = typeof ROUTER_PAGES[keyof typeof ROUTER_PAGES]
+export type RouterPage = typeof ROUTER_PAGES[keyof typeof ROUTER_PAGES];

--- a/src/shared/models/CanvasRequest.ts
+++ b/src/shared/models/CanvasRequest.ts
@@ -19,16 +19,21 @@ export const CANVAS_REQUEST_TYPE = {
     UsersSelf: 113,
     CoursesByTermId: 114,
   },
+  Put: {
+    Announcement: 200,
+  },
 } as const;
 
 export type CanvasRequestType = DeepValueOf<typeof CANVAS_REQUEST_TYPE>;
 export const CANVAS_REQUEST_GET = CANVAS_REQUEST_TYPE.Get;
+export const CANVAS_REQUEST_PUT = CANVAS_REQUEST_TYPE.Put;
 export type CanvasRequestGet = ValueOf<typeof CANVAS_REQUEST_GET>;
+export type CanvasRequestPut = ValueOf<typeof CANVAS_REQUEST_PUT>;
 
 export interface CanvasRequestInfo {
   id: string;
   created: number;
-  type: CanvasRequestGet;
+  type: CanvasRequestType;
   params: Record<string, any>;
 }
 
@@ -37,13 +42,14 @@ export class CanvasRequest {
   started: number | null;
   finished: number | null;
   id: string;
-  type: CanvasRequestGet;
+  type: CanvasRequestType;
   params: Record<string, any>;
 
   static readonly Get = CANVAS_REQUEST_TYPE.Get;
+  static readonly Put = CANVAS_REQUEST_TYPE.Put;
 
   constructor(
-    type: CanvasRequestGet,
+    type: CanvasRequestType,
     params: Record<string, any> = {},
     id: string = crypto.randomUUID(),
     created: number = Date.now()

--- a/src/shared/models/Message.test.ts
+++ b/src/shared/models/Message.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { CanvasRequest } from "./CanvasRequest";
+import { Message, MESSAGE_SENDER, MESSAGE_TARGET, MESSAGE_TYPE } from "./Message";
+import Task, { TaskTypes } from "./Task";
+
+describe("Message", () => {
+  it("constructs a side panel task creation request with the expected contract fields", () => {
+    const task = new Task(TaskTypes.coursesScan, {
+      searchTerms: ["retired faculty name"],
+      settings: ["include-html"],
+    });
+
+    const message = new Message(
+      MESSAGE_TARGET.SERVICE_WORKER,
+      MESSAGE_SENDER.SIDE_PANEL,
+      MESSAGE_TYPE.Task.Request.NEW,
+      "Start task",
+      task,
+      12345
+    );
+
+    expect(message).toMatchObject({
+      target: MESSAGE_TARGET.SERVICE_WORKER,
+      sender: MESSAGE_SENDER.SIDE_PANEL,
+      type: MESSAGE_TYPE.Task.Request.NEW,
+      text: "Start task",
+      data: task,
+      time: 12345,
+    });
+  });
+
+  it("defaults optional fields for a canvas request envelope", () => {
+    const request = new CanvasRequest(CanvasRequest.Get.UsersSelf);
+    const message = new Message(
+      MESSAGE_TARGET.TAB,
+      MESSAGE_SENDER.SERVICE_WORKER,
+      MESSAGE_TYPE.Canvas.REQUESTS,
+      undefined,
+      [request]
+    );
+
+    expect(message.target).toBe(MESSAGE_TARGET.TAB);
+    expect(message.sender).toBe(MESSAGE_SENDER.SERVICE_WORKER);
+    expect(message.type).toBe(MESSAGE_TYPE.Canvas.REQUESTS);
+    expect(message.text).toBe("");
+    expect(message.data).toEqual([request]);
+    expect(typeof message.time).toBe("number");
+  });
+});

--- a/src/shared/models/Task.test.ts
+++ b/src/shared/models/Task.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Task, { TaskStatuses, TaskTypes } from "./Task";
+
+describe("Task", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initializes a courses scan task with stable default lifecycle fields", () => {
+    const settingsData = {
+      searchTerms: ["retired faculty name", "old phone number"],
+      settings: ["case-sensitive"],
+    };
+    const task = new Task(TaskTypes.coursesScan, settingsData);
+
+    expect(task).toMatchObject({
+      id: -1,
+      uuid: "test-uuid",
+      type: TaskTypes.coursesScan,
+      status: TaskStatuses.NOT_STARTED,
+      progress: 0,
+      progressData: null,
+      errorsData: null,
+      settingsData,
+      resultsData: null,
+      controller: null,
+      timeStarted: null,
+      timeFinished: null,
+    });
+    expect(task.timeCreated).toBe(task.timeUpdated);
+  });
+
+  it("updates the task lifecycle timestamps as scan state changes", () => {
+    const task = new Task(TaskTypes.coursesScan);
+    const createdTime = task.timeUpdated;
+
+    vi.advanceTimersByTime(1000);
+    task.setStatus(TaskStatuses.RUNNING);
+    expect(task.status).toBe(TaskStatuses.RUNNING);
+    expect(task.timeUpdated).toBe(createdTime + 1000);
+
+    vi.advanceTimersByTime(1000);
+    task.setProgress(25);
+    task.setProgressData(["Scanning assignments"]);
+    expect(task.progress).toBe(25);
+    expect(task.progressData).toEqual(["Scanning assignments"]);
+    expect(task.timeUpdated).toBe(createdTime + 2000);
+
+    vi.advanceTimersByTime(1000);
+    task.setErrorsData(["Announcement request failed"]);
+    expect(task.errorsData).toEqual(["Announcement request failed"]);
+    expect(task.timeUpdated).toBe(createdTime + 3000);
+
+    vi.advanceTimersByTime(1000);
+    task.setResultsData({ resultsCount: 2 });
+    expect(task.resultsData).toEqual({ resultsCount: 2 });
+    expect(task.timeUpdated).toBe(createdTime + 4000);
+  });
+
+  it("records started and finished times for a completed scan", () => {
+    const task = new Task(TaskTypes.coursesScan);
+
+    vi.advanceTimersByTime(1000);
+    task.setTimeStarted();
+    expect(task.timeStarted).toBe(Date.parse("2025-01-01T00:00:01.000Z"));
+
+    vi.advanceTimersByTime(1000);
+    task.setStatus(TaskStatuses.COMPLETE);
+    task.setTimeFinished();
+    expect(task.status).toBe(TaskStatuses.COMPLETE);
+    expect(task.timeFinished).toBe(Date.parse("2025-01-01T00:00:02.000Z"));
+    expect(task.getTimes()).toEqual({
+      created: Date.parse("2025-01-01T00:00:00.000Z"),
+      started: Date.parse("2025-01-01T00:00:01.000Z"),
+      updated: Date.parse("2025-01-01T00:00:02.000Z"),
+      finished: Date.parse("2025-01-01T00:00:02.000Z"),
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,9 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["chrome", "vitest/globals"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "vitest.setup.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 import replace from "@rollup/plugin-replace";
@@ -16,8 +16,13 @@ const srcDir = resolve(rootDir, "src");
 export default defineConfig({
   plugins: [react()],
   publicDir: resolve(rootDir, "public"),
-  outDir: resolve(rootDir, "dist"),
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: [resolve(rootDir, "vitest.setup.ts")],
+  },
   build: {
+    outDir: resolve(rootDir, "dist"),
     minify: isProduction,
     rollupOptions: {
       input: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { Temporal } from "@js-temporal/polyfill";
 import { afterEach, vi } from "vitest";
 
 afterEach(() => {
@@ -14,6 +15,13 @@ Object.defineProperty(globalThis, "__app_description", {
   value: "test-description",
   configurable: true,
 });
+
+if (!("Temporal" in globalThis)) {
+  Object.defineProperty(globalThis, "Temporal", {
+    value: Temporal,
+    configurable: true,
+  });
+}
 
 Object.defineProperty(globalThis, "crypto", {
   value: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,43 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+Object.defineProperty(globalThis, "__app_version", {
+  value: "test-version",
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "__app_description", {
+  value: "test-description",
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "crypto", {
+  value: {
+    randomUUID: vi.fn(() => "test-uuid"),
+  },
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "chrome", {
+  value: {
+    runtime: {
+      onMessage: { addListener: vi.fn() },
+      sendMessage: vi.fn(),
+    },
+    tabs: {
+      get: vi.fn(),
+      query: vi.fn(),
+      onUpdated: { addListener: vi.fn() },
+      onRemoved: { addListener: vi.fn() },
+      onActivated: { addListener: vi.fn() },
+    },
+    sidePanel: {
+      setPanelBehavior: vi.fn(),
+    },
+  },
+  configurable: true,
+});


### PR DESCRIPTION
## Summary
- Adds announcement date adjustment tooling in the side panel, including preview/apply flow for shifting scheduled announcement post dates by a chosen day offset.
- Fixes service worker tab bootstrapping so already-open Canvas tabs are discovered without requiring a refresh after startup.
- Adds a Vitest-based regression suite covering shared contracts, service worker orchestration, Canvas tab tracking, date shifting, and Adjust Dates request payloads.

## Testing
- `npm run test:run`
- `npm run typecheck`

## Notes
- Date-shift tests use `@js-temporal/polyfill` in the test environment so Temporal-backed logic can be validated without relying on a Node experimental flag.
- The new coverage specifically protects the previously flaky “valid Canvas tab not detected until refresh” behavior and verifies announcement update requests are built with the correct shifted UTC timestamps.